### PR TITLE
Picking first value in custom code array for exception code

### DIFF
--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -49,7 +49,7 @@ class ValidationException extends NodesException
         }
 
         // Determine exception and status code
-        $exceptionCode = !empty($customErrorCodes) ? $customErrorCodes : 412;
+        $exceptionCode = !empty($customErrorCodes) ? array_shift($customErrorCodes) : 412;
         $statusCode = !empty($customErrorCodes) ? array_shift($customErrorCodes) : 412;
 
         // Construct exception


### PR DESCRIPTION
If a custom error code was supposed to be set it would set the array containing the error codes instead of the actual code.
